### PR TITLE
Fix duplicated Gnome Terminal icon in Plank

### DIFF
--- a/gnome-terminal.desktop.in.in
+++ b/gnome-terminal.desktop.in.in
@@ -14,7 +14,7 @@ X-GNOME-Bugzilla-Version=@VERSION@
 Categories=GNOME;GTK;System;TerminalEmulator;
 StartupNotify=true
 X-GNOME-SingleWindow=false
-OnlyShowIn=GNOME;Unity;
+OnlyShowIn=GNOME;Unity;X-Cinnamon;
 Actions=New
 
 [Desktop Action New]


### PR DESCRIPTION
Gnome Terminal's .desktop file didn't specify that it was to be used in Cinnamon sessions. As a consequence, Gnome Terminal has two entries visible in the dock application Plank when running Cinnamon. This is fixed by adding "X-Cinnamon" to the OnlyShowIn element.